### PR TITLE
Fix jessie libvirtd

### DIFF
--- a/libvirt/defaults.yaml
+++ b/libvirt/defaults.yaml
@@ -11,7 +11,7 @@ Debian:
     networks_dir: {}
     network_file: {}
   service:
-    name: libvirt-bin
+    name: libvirtd
   kvm:
     pkgs:
       - qemu-kvm

--- a/libvirt/kvm.sls
+++ b/libvirt/kvm.sls
@@ -21,7 +21,6 @@ ksm_servicescript:
     - mode: 755
     - user: root
     - group: root
-{% endif %}
 
 {% set kk = datamap.kvm.ksm|default({'service': {}}) %}
 ksm_service:
@@ -29,3 +28,4 @@ ksm_service:
     - {{ kk.service.state|default('running') }}
     - name: {{ kk.service.name|default('ksm') }}
     - enable: {{ kk.service.enable|default(True) }}
+{% endif %}


### PR DESCRIPTION
In Debian Jessie (8) libvirt-bin service is libvirtd.

Not sure if I could fix it in a better way...
