### PR TITLE
Fix virsh list

### DIFF
--- a/states/networks.sls
+++ b/states/networks.sls
@@ -32,10 +32,10 @@ libvirt_virsh_net_{{ name }}:
     - run
   {% if n.ensure|default('running') in ['present', 'running'] %}
     - name: virsh net-define {{ nf_path }}
-    - unless: virsh -q net-list --all | grep -q '^\s+{{ name }}'
+    - unless: virsh -q net-list --all | grep -Eq '^\s+{{ name }}'
  {% elif n.ensure|default('running') == 'absent' %}
     - name: virsh net-destroy {{ name }} 2>&1 1>/dev/null; virsh net-undefine {{ name }}
-    - onlyif: virsh -q net-list --all | grep -q '^\s+{{ name }}'
+    - onlyif: virsh -q net-list --all | grep -Eq '^\s+{{ name }}'
  {% endif %}
 
 libvirt_virsh_net-autostart_{{ name }}:

--- a/states/networks.sls
+++ b/states/networks.sls
@@ -54,9 +54,9 @@ libvirt_virsh_net_startstop_{{ name }}:
     - run
   {% if n.ensure|default('running') == 'running' %}
     - name: virsh net-start {{ name }}
-    - unless: virsh -q net-list --all | grep -Eq '^{{ name }}\s+active'
+    - unless: virsh -q net-list --all | grep -Eq '^\s?{{ name }}\s+active'
   {% elif n.ensure|default('running') in ['stopped', 'absent'] %}
     - name: virsh net-destroy {{ name }}
-    - onlyif: virsh -q net-list --all | grep -Eq '^{{ name }}\s+active'
+    - onlyif: virsh -q net-list --all | grep -Eq '^\s?{{ name }}\s+active'
   {% endif %}
 {% endfor %}

--- a/states/networks.sls
+++ b/states/networks.sls
@@ -32,10 +32,10 @@ libvirt_virsh_net_{{ name }}:
     - run
   {% if n.ensure|default('running') in ['present', 'running'] %}
     - name: virsh net-define {{ nf_path }}
-    - unless: virsh -q net-list --all | grep -q '^{{ name }}'
+    - unless: virsh -q net-list --all | grep -q '^\s+{{ name }}'
  {% elif n.ensure|default('running') == 'absent' %}
     - name: virsh net-destroy {{ name }} 2>&1 1>/dev/null; virsh net-undefine {{ name }}
-    - onlyif: virsh -q net-list --all | grep -q '^{{ name }}'
+    - onlyif: virsh -q net-list --all | grep -q '^\s+{{ name }}'
  {% endif %}
 
 libvirt_virsh_net-autostart_{{ name }}:

--- a/states/networks.sls
+++ b/states/networks.sls
@@ -32,10 +32,10 @@ libvirt_virsh_net_{{ name }}:
     - run
   {% if n.ensure|default('running') in ['present', 'running'] %}
     - name: virsh net-define {{ nf_path }}
-    - unless: virsh -q net-list --all | grep -Eq '^\s+{{ name }}'
+    - unless: virsh -q net-list --all | grep -Eq '^\s*{{ name }}'
  {% elif n.ensure|default('running') == 'absent' %}
     - name: virsh net-destroy {{ name }} 2>&1 1>/dev/null; virsh net-undefine {{ name }}
-    - onlyif: virsh -q net-list --all | grep -Eq '^\s+{{ name }}'
+    - onlyif: virsh -q net-list --all | grep -Eq '^\s*{{ name }}'
  {% endif %}
 
 libvirt_virsh_net-autostart_{{ name }}:
@@ -54,9 +54,9 @@ libvirt_virsh_net_startstop_{{ name }}:
     - run
   {% if n.ensure|default('running') == 'running' %}
     - name: virsh net-start {{ name }}
-    - unless: virsh -q net-list --all | grep -Eq '^\s?{{ name }}\s+active'
+    - unless: virsh -q net-list --all | grep -Eq '^\s*{{ name }}\s+active'
   {% elif n.ensure|default('running') in ['stopped', 'absent'] %}
     - name: virsh net-destroy {{ name }}
-    - onlyif: virsh -q net-list --all | grep -Eq '^\s?{{ name }}\s+active'
+    - onlyif: virsh -q net-list --all | grep -Eq '^\s*{{ name }}\s+active'
   {% endif %}
 {% endfor %}

--- a/states/pools.sls
+++ b/states/pools.sls
@@ -61,9 +61,9 @@ libvirt_virsh_pool_startstop_{{ name }}:
     - run
   {% if p.ensure|default('running') == 'running' %}
     - name: virsh pool-start {{ name }}
-    - unless: virsh -q pool-list --all | grep -Eq '^{{ name }}\s+active'
+    - unless: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}\s+active'
   {% elif p.ensure|default('running') in ['stopped', 'absent'] %}
     - name: virsh pool-destroy {{ name }}
-    - onlyif: virsh -q pool-list --all | grep -Eq '^{{ name }}\s+active'
+    - onlyif: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}\s+active'
   {% endif %}
 {% endfor %}

--- a/states/pools.sls
+++ b/states/pools.sls
@@ -39,10 +39,10 @@ libvirt_virsh_pool_{{ name }}:
     - run
   {% if p.ensure|default('running') in ['present', 'running'] %}
     - name: virsh pool-define {{ po_path }}
-    - unless: virsh -q pool-list --all | grep -q '^\s?{{ name }}'
+    - unless: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}'
  {% elif p.ensure|default('running') == 'absent' %}
     - name: virsh pool-destroy {{ name }} 2>&1 1>/dev/null; virsh pool-undefine {{ name }}
-    - onlyif: virsh -q pool-list --all | grep -q '^\s?{{ name }}'
+    - onlyif: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}'
  {% endif %}
 
 libvirt_pool_virsh_autostart_{{ name }}:

--- a/states/pools.sls
+++ b/states/pools.sls
@@ -39,10 +39,10 @@ libvirt_virsh_pool_{{ name }}:
     - run
   {% if p.ensure|default('running') in ['present', 'running'] %}
     - name: virsh pool-define {{ po_path }}
-    - unless: virsh -q pool-list --all | grep -q '^{{ name }}'
+    - unless: virsh -q pool-list --all | grep -q '^\s?{{ name }}'
  {% elif p.ensure|default('running') == 'absent' %}
     - name: virsh pool-destroy {{ name }} 2>&1 1>/dev/null; virsh pool-undefine {{ name }}
-    - onlyif: virsh -q pool-list --all | grep -q '^{{ name }}'
+    - onlyif: virsh -q pool-list --all | grep -q '^\s?{{ name }}'
  {% endif %}
 
 libvirt_pool_virsh_autostart_{{ name }}:

--- a/states/pools.sls
+++ b/states/pools.sls
@@ -39,10 +39,10 @@ libvirt_virsh_pool_{{ name }}:
     - run
   {% if p.ensure|default('running') in ['present', 'running'] %}
     - name: virsh pool-define {{ po_path }}
-    - unless: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}'
+    - unless: virsh -q pool-list --all | grep -Eq '^\s*{{ name }}'
  {% elif p.ensure|default('running') == 'absent' %}
     - name: virsh pool-destroy {{ name }} 2>&1 1>/dev/null; virsh pool-undefine {{ name }}
-    - onlyif: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}'
+    - onlyif: virsh -q pool-list --all | grep -Eq '^\s*{{ name }}'
  {% endif %}
 
 libvirt_pool_virsh_autostart_{{ name }}:
@@ -61,9 +61,9 @@ libvirt_virsh_pool_startstop_{{ name }}:
     - run
   {% if p.ensure|default('running') == 'running' %}
     - name: virsh pool-start {{ name }}
-    - unless: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}\s+active'
+    - unless: virsh -q pool-list --all | grep -Eq '^\s*{{ name }}\s+active'
   {% elif p.ensure|default('running') in ['stopped', 'absent'] %}
     - name: virsh pool-destroy {{ name }}
-    - onlyif: virsh -q pool-list --all | grep -Eq '^\s?{{ name }}\s+active'
+    - onlyif: virsh -q pool-list --all | grep -Eq '^\s*{{ name }}\s+active'
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
libvirt 1.2.9 apparently indents the net/storage pool names where
0.9.12 didn't, so the current regex fails. This fixes it so it
works with both versions.
